### PR TITLE
Add interfaces for frame interaction events

### DIFF
--- a/packages/frame-interactions/.babelrc
+++ b/packages/frame-interactions/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    ["@babel/preset-env", { "targets": { "node": "current" } }],
+    "@babel/preset-typescript"
+  ],
+  "plugins": ["babel-plugin-transform-vite-meta-env"]
+}

--- a/packages/frame-interactions/.gitignore
+++ b/packages/frame-interactions/.gitignore
@@ -1,0 +1,3 @@
+/dist/
+node_modules
+.DS_Store

--- a/packages/frame-interactions/README.md
+++ b/packages/frame-interactions/README.md
@@ -1,19 +1,13 @@
-# Template Package Library
+# Frame Interactions Package
 
-This template should help you get started developing new Package Libraries using typescript.
-
-# Setup
-
-1. Copy this directory under <root>/packages
-2. Open the `package.json` file and update the name to your desired package name. You can add extra package dependencies as required by your specific package in this file.
-3. You are now ready to go
+The package provides utilities in regards to frame interaction events. When using the event bus, we should strive to strongly type the sent types in order for a better code quality. The interfaces and types found in this package should help us achieve that.
 
 # Development
 
-By default, importing components from this library will take the files under the ```src``` directory. For example, using ```import utils from @circlesland/template-library-package``` will import it from ```packages/template-library-package```.
+You can add new interfaces or implementation in this package. To test the implementation, build the package and then use the defined structures in an app or another package by importing as follows: ```import { MyStuff } from '@circlesland/interaction-events'```.
 
 # Testing
-Run `yarn test` in the app directory to run unit tests. Unit tests are written using `jest`. There is a sample test file under `/src/testUtils.test.ts` that you can use as a reference.
+Run `yarn test` in the app directory to run unit tests. Unit tests are written using `jest`. The test runner searches for all files that end with ```.test.ts``` and runs them.
 
 
 # Build

--- a/packages/frame-interactions/README.md
+++ b/packages/frame-interactions/README.md
@@ -1,0 +1,22 @@
+# Template Package Library
+
+This template should help you get started developing new Package Libraries using typescript.
+
+# Setup
+
+1. Copy this directory under <root>/packages
+2. Open the `package.json` file and update the name to your desired package name. You can add extra package dependencies as required by your specific package in this file.
+3. You are now ready to go
+
+# Development
+
+By default, importing components from this library will take the files under the ```src``` directory. For example, using ```import utils from @circlesland/template-library-package``` will import it from ```packages/template-library-package```.
+
+# Testing
+Run `yarn test` in the app directory to run unit tests. Unit tests are written using `jest`. There is a sample test file under `/src/testUtils.test.ts` that you can use as a reference.
+
+
+# Build
+
+Run `yarn build` to build the package. The binaries will be located in the `dist` directory after the build is finished.
+

--- a/packages/frame-interactions/jest.config.json
+++ b/packages/frame-interactions/jest.config.json
@@ -1,0 +1,16 @@
+{
+  "transform": {
+    "^.+\\.svelte$": [
+      "svelte-jester",
+      {
+        "preprocess": true
+      }
+    ],
+    "^.+\\.ts$": "ts-jest",
+    "^.+\\.js$": "babel-jest"
+  },
+  "roots": ["./src"],
+  "moduleFileExtensions": ["svelte", "js", "ts"],
+  "testEnvironment": "jsdom",
+  "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"]
+}

--- a/packages/frame-interactions/package.json
+++ b/packages/frame-interactions/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@circlesland/frame-interactions",
+  "version": "1.0.0",
+  "description": "A library that defines support for frame interaction",
+  "svelte": "src/index.ts",
+  "module": "dist/index.mjs",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "rollup -c -w",
+    "build": "rollup -c",
+    "test": "jest -u --watch"
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "dependencies": {
+    "@circlesland/ui-components": "1.0.0"
+  }
+}

--- a/packages/frame-interactions/rollup.config.js
+++ b/packages/frame-interactions/rollup.config.js
@@ -1,0 +1,48 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from 'rollup-plugin-typescript2';
+import svelte from 'rollup-plugin-svelte';
+import autoPreprocess from 'svelte-preprocess';
+import { terser } from 'rollup-plugin-terser';
+
+import pkg from './package.json';
+
+const production = !process.env.ROLLUP_WATCH;
+const name = pkg.name
+  .replace(/^(@\S+\/)?(svelte-)?(\S+)/, '$3')
+  .replace(/^\w/, m => m.toUpperCase())
+  .replace(/-\w/g, m => m[1].toUpperCase());
+
+export default {
+  input: 'src/index.ts',
+  output: [
+    {
+      file: pkg.module,
+      format: 'es',
+      sourcemap: production,
+    },
+    {
+      file: pkg.main,
+      format: 'umd',
+      name,
+      sourcemap: production,
+    },
+  ],
+  plugins: [
+    commonjs(),
+    typescript(),
+    svelte({
+      dev: !production,
+      preprocess: autoPreprocess(),
+    }),
+    resolve({
+      dedupe: [
+        'svelte',
+      ],
+    }),
+    production && terser(),
+  ],
+  watch: {
+    clearScreen: false,
+  },
+};

--- a/packages/frame-interactions/src/index.ts
+++ b/packages/frame-interactions/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './interfaces';

--- a/packages/frame-interactions/src/interfaces/iinteraction-event.ts
+++ b/packages/frame-interactions/src/interfaces/iinteraction-event.ts
@@ -1,0 +1,6 @@
+import type { PromptEventPayload, InteractionType } from "../types";
+
+export interface IInteractionEvent {
+    interactionType: InteractionType,
+    payload?: PromptEventPayload | any;
+}

--- a/packages/frame-interactions/src/interfaces/index.ts
+++ b/packages/frame-interactions/src/interfaces/index.ts
@@ -1,0 +1,1 @@
+export type { IInteractionEvent } from './iinteraction-event';

--- a/packages/frame-interactions/src/types/index.ts
+++ b/packages/frame-interactions/src/types/index.ts
@@ -1,0 +1,2 @@
+export { InteractionType } from './interaction-type';
+export type { PromptEventPayload } from './prompt-event-payload';

--- a/packages/frame-interactions/src/types/interaction-type.ts
+++ b/packages/frame-interactions/src/types/interaction-type.ts
@@ -1,0 +1,11 @@
+/**
+ * An enumeration that defines the type of interaction
+ */
+export enum InteractionType {
+    Continue = 'CONTINUE',
+    Skip = 'SKIP',
+    Back = 'BACK',
+    Submit = 'SUBMIT',
+    Cancel = 'CANCEL',
+    Propmpt = 'PROMPT' 
+}

--- a/packages/frame-interactions/src/types/navigation-info.ts
+++ b/packages/frame-interactions/src/types/navigation-info.ts
@@ -1,0 +1,5 @@
+export interface NavigationInfo {
+    canContinue?: boolean;
+    canGoBack?: boolean;
+    canSkip?: boolean;
+}

--- a/packages/frame-interactions/src/types/prompt-event-payload.ts
+++ b/packages/frame-interactions/src/types/prompt-event-payload.ts
@@ -1,0 +1,10 @@
+import type { NavigationInfo } from './navigation-info';
+import type { ViewType } from '@circlesland/ui-components';
+
+export interface PromptEventPayload {
+  id: string;
+  title: string;
+  navigationInfo: NavigationInfo;
+  params: { [key: string]: any };
+  viewType: ViewType;
+}

--- a/packages/frame-interactions/tsconfig.json
+++ b/packages/frame-interactions/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    /**
+     * Typecheck JS in `.svelte` and `.js` files by default.
+     * Disable checkJs if you'd like to use dynamic types in JS.
+     * Note that setting allowJs false does not prevent the use
+     * of JS in `.svelte` files.
+     */
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedModules": true,
+    "types": [
+      "reflect-metadata",
+      "jest"
+    ],
+    "typeRoots": [
+      "../../node_modules/@types"
+    ]
+  },
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/packages/frame-interactions/tsconfig.node.json
+++ b/packages/frame-interactions/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/localization/README.md
+++ b/packages/localization/README.md
@@ -1,19 +1,13 @@
-# Template Package Library
+# Localization Package
 
-This template should help you get started developing new Package Libraries using typescript.
-
-# Setup
-
-1. Copy this directory under <root>/packages
-2. Open the `package.json` file and update the name to your desired package name. You can add extra package dependencies as required by your specific package in this file.
-3. You are now ready to go
+The package provides support for localizing strings, dates and numbers but can be extended more as we progress. The package exports a "LocalizationService" that allows localization from either component level or just a function implementation level.
 
 # Development
 
-By default, importing components from this library will take the files under the ```src``` directory. For example, using ```import utils from @circlesland/template-library-package``` will import it from ```packages/template-library-package```.
+You can add new interfaces or implementation in this package. To test the implementation, build the package and then use the defined structures in an app or another package by importing as follows: ```import { MyStuff } from '@circlesland/localization'```.
 
 # Testing
-Run `yarn test` in the app directory to run unit tests. Unit tests are written using `jest`. There is a sample test file under `/src/testUtils.test.ts` that you can use as a reference.
+Run `yarn test` in the app directory to run unit tests. Unit tests are written using `jest`. The test runner searches for all files that end with ```.test.ts``` and runs them.
 
 
 # Build

--- a/packages/ui-components/.babelrc
+++ b/packages/ui-components/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    ["@babel/preset-env", { "targets": { "node": "current" } }],
+    "@babel/preset-typescript"
+  ],
+  "plugins": ["babel-plugin-transform-vite-meta-env"]
+}

--- a/packages/ui-components/.gitignore
+++ b/packages/ui-components/.gitignore
@@ -1,0 +1,3 @@
+/dist/
+node_modules
+.DS_Store

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -1,25 +1,16 @@
-# Template UI Package Library
+# UI Components Package
 
-This template should help you get started developing new UI Package Libraries using Svelte and Typescript in Vite.
-
-# Setup
-
-1. Copy this directory under <root>/packages
-2. Open the `package.json` file and update the name to your desired application name. You can add extra package dependencies as required by your specific package in this file.
-3. You are now ready to go
+The package implements a series of basic UI Components written in Svelte. The components can then either be used in other View Componnets or can be used to dynamically build forms based on a common interface (Ex: View/ViewType).
 
 # Development
 
-By default, importing components from this library will take the files under the ```src``` directory. For example, using ```import Counter from @circlesland/template-ui-library-package``` will import it from ```packages/template-ui-library-package```.
+You can add new interfaces or components in this package. To test the implementation, build the package and then use the defined structures in an app or another package by importing as follows: ```import { MyStuff } from '@circlesland/ui-components'```.
 
 # Testing
-Run `yarn test` in the app directory to run unit tests. Unit tests are written using `jest`. There is a sample test file under `/src/Counter.test.ts` that you can use as a reference.
+Run `yarn test` in the app directory to run unit tests. Unit tests are written using `jest`. The test runner searches for all files that end with ```.test.ts``` and runs them.
 
 
 # Build
 
 Run `yarn build` to build the package. The binaries will be located in the `dist` directory after the build is finished.
 
-# Storybook
-
-Each component should contain stories written in order to display them in **Storybook**. You can write component stories by using the ```<component-name>.stories.ts``` file structure. Storybook searches automatically for ***.stories.ts** files and displays the associated components.

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -1,0 +1,25 @@
+# Template UI Package Library
+
+This template should help you get started developing new UI Package Libraries using Svelte and Typescript in Vite.
+
+# Setup
+
+1. Copy this directory under <root>/packages
+2. Open the `package.json` file and update the name to your desired application name. You can add extra package dependencies as required by your specific package in this file.
+3. You are now ready to go
+
+# Development
+
+By default, importing components from this library will take the files under the ```src``` directory. For example, using ```import Counter from @circlesland/template-ui-library-package``` will import it from ```packages/template-ui-library-package```.
+
+# Testing
+Run `yarn test` in the app directory to run unit tests. Unit tests are written using `jest`. There is a sample test file under `/src/Counter.test.ts` that you can use as a reference.
+
+
+# Build
+
+Run `yarn build` to build the package. The binaries will be located in the `dist` directory after the build is finished.
+
+# Storybook
+
+Each component should contain stories written in order to display them in **Storybook**. You can write component stories by using the ```<component-name>.stories.ts``` file structure. Storybook searches automatically for ***.stories.ts** files and displays the associated components.

--- a/packages/ui-components/jest.config.json
+++ b/packages/ui-components/jest.config.json
@@ -1,0 +1,16 @@
+{
+  "transform": {
+    "^.+\\.svelte$": [
+      "svelte-jester",
+      {
+        "preprocess": true
+      }
+    ],
+    "^.+\\.ts$": "ts-jest",
+    "^.+\\.js$": "babel-jest"
+  },
+  "roots": ["./src"],
+  "moduleFileExtensions": ["svelte", "js", "ts"],
+  "testEnvironment": "jsdom",
+  "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"]
+}

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@circlesland/ui-components",
+  "version": "1.0.0",
+  "description": "A Svelte component library for circlesland",
+  "svelte": "src/index.ts",
+  "module": "dist/index.mjs",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "rollup -c -w",
+    "svelte-check": "svelte-check",
+    "build": "rollup -c",
+    "prepublishOnly": "npm run svelte-check && npm run build",
+    "test": "jest -u --watch"
+  },
+  "keywords": [
+    "component",
+    "svelte"
+  ],
+  "files": [
+    "src",
+    "dist"
+  ]
+}

--- a/packages/ui-components/rollup.config.js
+++ b/packages/ui-components/rollup.config.js
@@ -1,0 +1,48 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from 'rollup-plugin-typescript2';
+import svelte from 'rollup-plugin-svelte';
+import autoPreprocess from 'svelte-preprocess';
+import { terser } from 'rollup-plugin-terser';
+
+import pkg from './package.json';
+
+const production = !process.env.ROLLUP_WATCH;
+const name = pkg.name
+  .replace(/^(@\S+\/)?(svelte-)?(\S+)/, '$3')
+  .replace(/^\w/, m => m.toUpperCase())
+  .replace(/-\w/g, m => m[1].toUpperCase());
+
+export default {
+  input: 'src/index.ts',
+  output: [
+    {
+      file: pkg.module,
+      format: 'es',
+      sourcemap: production,
+    },
+    {
+      file: pkg.main,
+      format: 'umd',
+      name,
+      sourcemap: production,
+    },
+  ],
+  plugins: [
+    commonjs(),
+    typescript(),
+    svelte({
+      dev: !production,
+      preprocess: autoPreprocess(),
+    }),
+    resolve({
+      dedupe: [
+        'svelte',
+      ],
+    }),
+    production && terser(),
+  ],
+  watch: {
+    clearScreen: false,
+  },
+};

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/ui-components/src/types/index.ts
+++ b/packages/ui-components/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './view';

--- a/packages/ui-components/src/types/validator.ts
+++ b/packages/ui-components/src/types/validator.ts
@@ -1,0 +1,1 @@
+export type ValidatorFn = (value: any) => boolean;

--- a/packages/ui-components/src/types/view.ts
+++ b/packages/ui-components/src/types/view.ts
@@ -1,0 +1,18 @@
+/**
+ * An interface that defines currently supported view types
+ */
+export enum ViewType {
+    HORIZONTAL_LAYOUT,
+    VERTICAL_LAYOUT
+}
+
+/**
+ * Basic view definition for a UI Component. All UI Components should derive from this interface
+ */
+export interface View {
+    id: string;
+    testId: string;
+    type: ViewType;
+    args: { [key: string]: any };
+    children?: View[]
+}

--- a/packages/ui-components/src/types/view.ts
+++ b/packages/ui-components/src/types/view.ts
@@ -1,3 +1,5 @@
+import type { ValidatorFn } from "./validator";
+
 /**
  * An interface that defines currently supported view types
  */
@@ -14,5 +16,7 @@ export interface View {
     testId: string;
     type: ViewType;
     args: { [key: string]: any };
-    children?: View[]
+    validators?: ValidatorFn[];
+    children?: View[];
+    valueChange?: (value: any) => void;
 }

--- a/packages/ui-components/svelte.config.js
+++ b/packages/ui-components/svelte.config.js
@@ -1,0 +1,5 @@
+const autoPreprocess = require('svelte-preprocess');
+
+module.exports = {
+  preprocess: autoPreprocess(),
+};

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    /**
+     * Typecheck JS in `.svelte` and `.js` files by default.
+     * Disable checkJs if you'd like to use dynamic types in JS.
+     * Note that setting allowJs false does not prevent the use
+     * of JS in `.svelte` files.
+     */
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedModules": true,
+    "types": [
+      "reflect-metadata",
+      "jest"
+    ],
+    "typeRoots": [
+      "../../node_modules/@types"
+    ]
+  },
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/packages/ui-components/tsconfig.node.json
+++ b/packages/ui-components/tsconfig.node.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node"
+  },
+  "include": ["vite.config.ts"]
+}


### PR DESCRIPTION
- Add interface for "InteractionEvent" with the following arguents:
    - event type -> (ex: prompt, cancel, continue, etc)
    - event payload -> mostly used for prompts since the other ones don't seem to require a payload at this point (Ex: cancel)

- Add interface for a component view -> This might change in the future but I needed a basic implementation for the frame interaction event definitions