### PR TITLE
Fix build for interfaces channels

### DIFF
--- a/packages/interfaces-channels/src/interfaces/IEndpoint.ts
+++ b/packages/interfaces-channels/src/interfaces/IEndpoint.ts
@@ -1,4 +1,6 @@
-import {DestroyEventSinkSubscription, IEvent} from "@circlesland/interfaces-channels";
+import { IEvent } from "./IEvent";
+import { DestroyEventSinkSubscription } from "./IEventSink";
+
 
 export interface IEndpoint {
   send(event: IEvent):void;


### PR DESCRIPTION
An incorrect import in the "interfaces-channels" package was causing the build to fail. Fixed it now