### PR TITLE
Dispatch event from button on button click

### DIFF
--- a/packages/ui-components/cypress/tests/button.cy.ts
+++ b/packages/ui-components/cypress/tests/button.cy.ts
@@ -4,14 +4,10 @@ import { waitForAsync } from '../support/commands';
 
 describe('Button', () => {
   const buttonSelector = '[data-testId="button-test-id"]';
-  it('should display a button with an icon', async () => {
-    let clickCount = 0;
-    const clickCallback = () => {
-      clickCount++;
-    };
-    const view: View & ButtonType = {
+  it('should display a button with an icon', (done) => {
+    const buttonView: View & ButtonType = {
       id: 'button',
-      callback: clickCallback,
+      trigger: 'test-trigger-name',
       type: ViewType.BUTTON,
       testId: 'button-test-id',
       args: {
@@ -27,22 +23,57 @@ describe('Button', () => {
       },
     };
 
-    cy.mount(Button, { props: { view } });
-    cy.get(buttonSelector).click();
+    cy.mount(Button, { props: { view: buttonView } });
+    
+    cy.get(buttonSelector).then((jQueryButton) => {
+      const buttonElement = jQueryButton[0];
+      buttonElement.addEventListener('test-trigger-name', (e) => {
+        const { view, eventDetails } = e.detail;
 
-    await waitForAsync(() => clickCount === 1);
-    expect(clickCount).to.eq(1);
+        expect(eventDetails).to.not.be.undefined;
+        expect(buttonView.id).to.eq(view.id);
+        done();
+      });
+    });
+
+    cy.get(buttonSelector).click();
   });
 
-  it('should display a circular icon button', async () => {
-    let clickCount = 0;
-    const clickCallback = () => {
-      clickCount++;
+  it('should display a button with text', (done) => {
+    const buttonView: View & ButtonType = {
+      id: 'button',
+      trigger: 'test-trigger-name',
+      type: ViewType.BUTTON,
+      testId: 'button-test-id',
+      args: {
+        type: ButtonTypes.Default,
+        labelConfig: {
+          label: 'Button',
+          localizationKey: 'button-localization-key',
+        }
+      },
     };
 
-    const view: View & ButtonType = {
+    cy.mount(Button, { props: { view: buttonView } });
+    
+    cy.get(buttonSelector).then((jQueryButton) => {
+      const buttonElement = jQueryButton[0];
+      buttonElement.addEventListener('test-trigger-name', (e) => {
+        const { view, eventDetails } = e.detail;
+
+        expect(eventDetails).to.not.be.undefined;
+        expect(buttonView.id).to.eq(view.id);
+        done();
+      });
+    });
+
+    cy.get(buttonSelector).click();
+  });
+
+  it('should display a circular icon button', (done) => {
+    const buttonView: View & ButtonType = {
       id: 'button',
-      callback: clickCallback,
+      trigger: 'test-trigger-name',
       type: ViewType.BUTTON,
       testId: 'button-test-id',
       args: {
@@ -54,10 +85,19 @@ describe('Button', () => {
       },
     };
 
-    cy.mount(Button, { props: { view } });
-    cy.get(buttonSelector).click();
+    cy.mount(Button, { props: { view: buttonView } });
+    
+    cy.get(buttonSelector).then((jQueryButton) => {
+      const buttonElement = jQueryButton[0];
+      buttonElement.addEventListener('test-trigger-name', (e) => {
+        const { view, eventDetails } = e.detail;
 
-    await waitForAsync(() => clickCount === 1);
-    expect(clickCount).to.eq(1);
+        expect(eventDetails).to.not.be.undefined;
+        expect(buttonView.id).to.eq(view.id);
+        done();
+      });
+    });
+
+    cy.get(buttonSelector).click();
   });
 });

--- a/packages/ui-components/src/components/Button/Button.svelte
+++ b/packages/ui-components/src/components/Button/Button.svelte
@@ -6,7 +6,7 @@
 
   export let view: View & ButtonType;
 
-  const { testId, args, callback } = view;
+  const { testId, args, trigger } = view;
   const { labelConfig, type, customTheme, icon } = args;
   const { localizationKey, label} = labelConfig || {};
 
@@ -42,15 +42,18 @@ function getCircularButtonWidth(customTheme: CustomButtonTheme): number {
       default: return `${baseClass} font-bold py-2 px-4 rounded-full`;
     }
   };
-
-  function handleButtonClick() {
-    callback();
+  
+  let buttonRef;
+  function handleButtonClick(e) {
+    const eventName = trigger ?? 'trigger';
+    buttonRef.dispatchEvent(new CustomEvent(eventName, { detail: { view, eventDetails: e }}))
   }
 </script>
 
 {#if view}
   {#if type === ButtonTypes.CircularWithIcon}
     <button
+      bind:this={buttonRef}
       class={getButtonClass(type)}
       data-testId={testId}
       on:click={handleButtonClick}
@@ -64,6 +67,7 @@ function getCircularButtonWidth(customTheme: CustomButtonTheme): number {
     </button>
   {:else if type === ButtonTypes.IconText}
     <button
+      bind:this={buttonRef}
       class={getButtonClass(type)}
       data-testId={testId}
       data-i18n-key={localizationKey}
@@ -79,6 +83,7 @@ function getCircularButtonWidth(customTheme: CustomButtonTheme): number {
     </button>
   {:else}
     <button
+      bind:this={buttonRef}
       class={getButtonClass(type)}
       data-testId={testId}
       data-i18n-key={localizationKey}

--- a/packages/ui-components/src/types/view.ts
+++ b/packages/ui-components/src/types/view.ts
@@ -26,7 +26,6 @@ export enum ViewType {
 export type View = {
   id: string;
   testId: string;
-  callback: any;
   type: ViewType;
   args?: { [key: string]: any };
   validators?: Validator;


### PR DESCRIPTION
Instead of adding channel specific implementation in the ui-components, we should have them generic enough so that they can be reused. Updated the button component to dispatch an event when clicked. Updated the cypress tests based on the new behavior.