### PR TITLE
remove channels from ui-components

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -34,9 +34,6 @@
     "@krowten/svelte-heroicons": "^0.0.6"
   },
   "dependencies": {
-    "@circlesland/xstate-validators": "1.0.0",
-    "@circlesland/channels": "1.0.0",
-    "@circlesland/interfaces-channels": "1.0.0",
     "autoprefixer": "^10.4.8",
     "postcss": "^8.4.16",
     "tailwindcss": "^3.1.8",

--- a/packages/ui-components/src/components/VerticalLayout/VerticalLayout.svelte
+++ b/packages/ui-components/src/components/VerticalLayout/VerticalLayout.svelte
@@ -1,34 +1,11 @@
 <script lang="ts">
-  import type {
-    IChannel,
-    IDuplexChannel,
-  } from '@circlesland/interfaces-channels';
   import type { VerticalLayout } from '../../types';
-  import {
-    DuplexChannel,
-    PostMessageSink,
-    PostMessageSource,
-  } from '@circlesland/channels';
   import type { View } from '../../types';
   import { SupportedViews } from '../../types/supported';
 
   export let view: View & VerticalLayout;
 
   const classList = 'flex flex-col justify-around flex-wrap max-w-full';
-
-  const trigger = (trg: string) => {
-    const source = new PostMessageSource(window.parent, '*');
-    const sink = new PostMessageSink(window, window.location.origin);
-
-    const duplexChannel: IDuplexChannel = new DuplexChannel(source, sink);
-
-    duplexChannel.endpoint.send({
-      id: '2',
-      type: 'safeDappSdkMessage',
-      method: trg,
-      requestId: '1234',
-    });
-  };
 </script>
 
 {#if view && view.children}
@@ -38,7 +15,6 @@
         <svelte:component
           this={SupportedViews[child.type]}
           view={child}
-          on:click={() => trigger(child.trigger)}
         />
       {:else}
         <svelte:component this={SupportedViews[child.type]} view={child} />


### PR DESCRIPTION
Components from the "ui-components" package should be generic and not contain any business implementation. The events are bubbled up from individual components(ex: button) and it will be the responsibility of the custom container to catch them and act accordingly.

Removed the "interfaces-channels" and "channels" references from the "ui-components" package