### PR TITLE
Initialize communication between frame app iframe and loaded app

### DIFF
--- a/apps/banking-dapp/src/App.svelte
+++ b/apps/banking-dapp/src/App.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import { DuplexChannel, PostMessageSink, PostMessageSource } from '@circlesland/channels';
+    import type { IDuplexChannel } from '@circlesland/interfaces-channels';
+    import { onMount } from 'svelte';
     import { FundsLabel } from "./components";
     import { Currency } from "./components/FundsLabel/types";
 
@@ -6,7 +9,29 @@
     let balance = 200;
     let balanceCurrency = Currency.EUR;
 
-    // Configure the channel communication
+    let source: PostMessageSource = null;
+    let sink: PostMessageSink = null;
+    let channel: IDuplexChannel = null;
+
+    function handleInitialization(e) {
+        source = new PostMessageSource(window.top, e.data.sinkOrigin);
+        sink = new PostMessageSink(window, window.location.origin);
+
+        channel = new DuplexChannel(source, sink);
+
+        window.removeEventListener('message', handleInitialization);
+    }
+
+    setTimeout(() => {
+        channel.endpoint.send({
+            type: 'safeDappSdkMessage',
+            id: '15'
+        });
+    }, 3000);
+
+    onMount(() => {
+        const listener = window.addEventListener('message', handleInitialization);
+    });
 </script>
 
 <div class="flex flex-col h-full">

--- a/packages/frame-app/src/pages/AppView.svelte
+++ b/packages/frame-app/src/pages/AppView.svelte
@@ -39,7 +39,13 @@
 
   const onIframeLoad = async () => {
     const iframeEl = document.getElementById('appFrame') as HTMLIFrameElement;
-
+    
+    const initializationData = {
+      // TODO: Take this from the manifest
+      sinkOrigin: 'http://localhost:3000'
+    };
+    iframeEl.contentWindow.postMessage(initializationData, appManifest?.url);
+  
     if (!frameCommunicator && iframeEl) {
       const source = new PostMessageSource(
         iframeEl.contentWindow,
@@ -48,7 +54,7 @@
       const sink = new PostMessageSink(window, window.location.origin);
 
       const duplexChannel: IDuplexChannel = new DuplexChannel(source, sink);
-      sink.receive('safeDappSdkMessage', async (safeDappSdkMessage) => {
+      duplexChannel.endpoint.receive('safeDappSdkMessage', async (safeDappSdkMessage) => {
         console.log('got now', safeDappSdkMessage);
         switch (safeDappSdkMessage.method) {
           case Methods.init:


### PR DESCRIPTION
Setup the "banking dapp" with initialization between the frame app (iframe) and the app itself. The initialization consists in creating a duplex channel and sending some initialization messages.